### PR TITLE
Fixed OpenSSL submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	ignore = dirty
 [submodule "Tor/openssl"]
 	path = Tor/openssl
-	url = git://git.openssl.org/openssl.git
+	url = git://github.com/openssl/openssl.git
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ matrix:
   include:
     - xcode_scheme: "Tor-iOS"
       xcode_sdk: iphoneos
-      osx_image: xcode8
+      osx_image: xcode9
       env:
         - XCODE_ACTION=build
         - XCODE_DESTINATION="generic/platform=iOS"
     - xcode_scheme: "Tor-iOS"
       xcode_sdk: iphonesimulator
-      osx_image: xcode8
+      osx_image: xcode9
       env:
         - XCODE_ACTION=build
         - XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 7"
     - xcode_scheme: "Tor-Mac"
       xcode_sdk: macosx
-      osx_image: xcode8
+      osx_image: xcode9
       env:
         - XCODE_ACTION=build
         - XCODE_DESTINATION="arch=x86_64"


### PR DESCRIPTION
Original git.openssl.org repo is down, use Github copy instead.
Updated travis config to use Xcode9 osx_image.