### PR TITLE
Update tor to 0.3.4.8 and solve crash/restart problem

### DIFF
--- a/Tor.xcodeproj/project.pbxproj
+++ b/Tor.xcodeproj/project.pbxproj
@@ -718,7 +718,9 @@
 		D0FBEC641B79BAD7005C7577 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				DefaultBuildSystemTypeForWorkspace = Latest;
+				LastSwiftUpdateCheck = 1000;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "Conrad Kramer";
 				TargetAttributes = {
 					D012AB841BC290D0004BE7A6 = {

--- a/Tor.xcodeproj/xcshareddata/xcschemes/Host-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/Host-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/Host-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/Host-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/Tor-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/Tor-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/Tor-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/Tor-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/libevent-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/libevent-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/libevent-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/libevent-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/openssl-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/openssl-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/openssl-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/openssl-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/tor-static-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/tor-static-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/tor-static-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/tor-static-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/xz-Mac.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/xz-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor.xcodeproj/xcshareddata/xcschemes/xz-iOS.xcscheme
+++ b/Tor.xcodeproj/xcshareddata/xcschemes/xz-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tor/TORController.h
+++ b/Tor/TORController.h
@@ -28,6 +28,7 @@ NS_SWIFT_NAME(TorController)
 - (instancetype)initWithSocketHost:(NSString *)host port:(in_port_t)port NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)connect:(out NSError **)error;
+- (void)disconnect;
 
 // Commands
 - (void)authenticateWithData:(NSData *)data completion:(void (^__nullable)(BOOL success, NSError * __nullable error))completion;

--- a/Tor/TORThread.m
+++ b/Tor/TORThread.m
@@ -20,6 +20,7 @@ static __weak TORThread *_thread = nil;
 @interface TORThread ()
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *arguments;
+@property (nonatomic) tor_main_configuration_t *cfg;
 
 @end
 
@@ -69,10 +70,10 @@ static __weak TORThread *_thread = nil;
     event_enable_debug_mode();
 #endif
 
-    tor_main_configuration_t *cfg = tor_main_configuration_new();
-    tor_main_configuration_set_command_line(cfg, argc, argv);
-    tor_run_main(cfg);
-    tor_main_configuration_free(cfg);
+    self.cfg = tor_main_configuration_new();
+    tor_main_configuration_set_command_line(self.cfg, argc, argv);
+    tor_run_main(self.cfg);
+    tor_main_configuration_free(self.cfg);
 }
 
 @end

--- a/Tor/TORThread.m
+++ b/Tor/TORThread.m
@@ -20,7 +20,6 @@ static __weak TORThread *_thread = nil;
 @interface TORThread ()
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *arguments;
-@property (nonatomic) tor_main_configuration_t *cfg;
 
 @end
 
@@ -70,10 +69,10 @@ static __weak TORThread *_thread = nil;
     event_enable_debug_mode();
 #endif
 
-    self.cfg = tor_main_configuration_new();
-    tor_main_configuration_set_command_line(self.cfg, argc, argv);
-    tor_run_main(self.cfg);
-    tor_main_configuration_free(self.cfg);
+    tor_main_configuration_t *cfg = tor_main_configuration_new();
+    tor_main_configuration_set_command_line(cfg, argc, argv);
+    tor_run_main(cfg);
+    tor_main_configuration_free(cfg);
 }
 
 @end


### PR DESCRIPTION
Seems like I kinda fixed the crash/restarting problem.
Updated the tor instance used to 0.3.4.8.
And added an `disconnect` function on the `TorController`.
The disconnect function performs a `NEWNYM` call, a `SIGNAL SHUTDOWN` call and than it shuts down the socket and sets the channel to nil.

In my code I call the disconnect method on `AppDelegate.applicationDidEnterBackground`
And destroy the previous thread so I can make a new one when activating the application again.

I wasn't able to build this branch via Carthage yet... it gives errors about missing the `<event2/event-config.h>` include.
I'll try to dig into that some more.

My objc skill level is very low, so I think somethings might need to be refactored. 💯

This solves #37 and #36 