### PR TITLE
Fix the handling of some escaped info values.

### DIFF
--- a/Tor/TORController.m
+++ b/Tor/TORController.m
@@ -495,7 +495,8 @@ static NSString * const TORControllerEndReplyLineSeparator = @" ";
                                      NSCharacterSet.doubleQuote];
 
                     [components removeObjectAtIndex:0];
-                    NSString* value = [components componentsJoinedByString:@"="];
+                    NSString* value = [[components componentsJoinedByString:@"="]
+                                       stringByTrimmingCharactersInSet:NSCharacterSet.doubleQuote];
 
                     if ([keys containsObject:key])
                     {


### PR DESCRIPTION
v400.6.1 broke the -[TorController getSessionConfiguration:] since the socks address is (sometimes) escaped. This PR readds the same (incomplete) handling of such escaped values as apparently got lost in the rewrite of -[TorController getInfoForKeys:completion:].