### PR TITLE
Several warnings fixed

### DIFF
--- a/Tor/TORConfiguration.m
+++ b/Tor/TORConfiguration.m
@@ -11,6 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation TORConfiguration
 
+static NSString * const kDataDirectory = @"DataDirectory";
+static NSString * const kControlSocket = @"ControlSocket";
+static NSString * const kSocksPort = @"SocksPort";
+static NSString * const kCookieAuthentication = @"CookieAuthentication";
+
 - (NSDictionary *)options {
     if (!_options)
         _options = [NSDictionary new];
@@ -27,34 +32,42 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setDataDirectory:(nullable NSURL *)dataDirectory {
     NSMutableDictionary *options = [self.options mutableCopy];
-    options[@"DataDirectory"] = @(dataDirectory.fileSystemRepresentation);
+    if (!dataDirectory) {
+        [options removeObjectForKey:kDataDirectory];
+    } else {
+        options[kDataDirectory] = @((const char * _Nonnull)dataDirectory.fileSystemRepresentation);
+    }
     self.options = options;
 }
 
 - (nullable NSURL *)dataDirectory {
-    NSString *path = self.options[@"DataDirectory"];
+    NSString *path = self.options[kDataDirectory];
     return (path ? [NSURL fileURLWithPath:path] : nil);
 }
 
 - (void)setControlSocket:(nullable NSURL *)controlSocket {
     NSMutableDictionary *options = [self.options mutableCopy];
-    options[@"ControlSocket"] = @(controlSocket.fileSystemRepresentation);
+    if (!controlSocket) {
+        [options removeObjectForKey:kControlSocket];
+    } else {
+        options[kControlSocket] = @((const char * _Nonnull)controlSocket.fileSystemRepresentation);
+    }
     self.options = options;
 }
 
 - (nullable NSURL *)controlSocket {
-    NSString *path = self.options[@"ControlSocket"];
+    NSString *path = self.options[kControlSocket];
     return (path ? [NSURL fileURLWithPath:path] : nil);
 }
 
 - (void)setSocksURL:(nullable NSURL *)socksURL {
     NSMutableDictionary *options = [_options mutableCopy];
-    [options setObject:[NSString stringWithFormat:@"unix:%s", socksURL.fileSystemRepresentation] forKey:@"SocksPort"];
+    [options setObject:[NSString stringWithFormat:@"unix:%s", socksURL.fileSystemRepresentation] forKey:kSocksPort];
     self.options = options;
 }
 
 - (nullable NSURL *)socksURL {
-    NSArray<NSString *> *components = [self.options[@"SocksPort"] componentsSeparatedByString:@":"];
+    NSArray<NSString *> *components = [self.options[kSocksPort] componentsSeparatedByString:@":"];
     if ([components.firstObject isEqualToString:@"unix"])
         return [NSURL fileURLWithPath:[[components subarrayWithRange:NSMakeRange(1, components.count - 1)] componentsJoinedByString:@":"]];
     
@@ -63,12 +76,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setCookieAuthentication:(nullable NSNumber *)cookieAuthentication {
     NSMutableDictionary *options = [self.options mutableCopy];
-    options[@"CookieAuthentication"] = (cookieAuthentication.boolValue ? @"1" : @"0");
+    options[kCookieAuthentication] = (cookieAuthentication.boolValue ? @"1" : @"0");
     self.options = options;
 }
 
 - (nullable NSNumber *)cookieAuthentication {
-    NSString *cookieAuthentication = self.options[@"CookieAuthentication"];
+    NSString *cookieAuthentication = self.options[kCookieAuthentication];
     return (cookieAuthentication ? @(cookieAuthentication.boolValue) : nil);
 }
 

--- a/Tor/TORNode.m
+++ b/Tor/TORNode.m
@@ -100,10 +100,11 @@ static NSRegularExpression *_ipv6Regex;
         return nil;
     }
 
+    NSString *countryCode = (NSString * _Nonnull)self.countryCode;
     if (@available(iOS 10.0, macOS 10.12, *)) {
-        return [NSLocale.currentLocale localizedStringForCountryCode:self.countryCode];
+        return [NSLocale.currentLocale localizedStringForCountryCode:countryCode];
     } else {
-        return [NSLocale.currentLocale displayNameForKey:NSLocaleCountryCode value:self.countryCode];
+        return [NSLocale.currentLocale displayNameForKey:NSLocaleCountryCode value:countryCode];
     }
 }
 


### PR DESCRIPTION
- Several `"Implicit conversion from nullable pointer to non-nullable pointer type"` warnings fixed; 
- constant strings are used as keys in options dictionary in `TORConfiguration`;