### PR TITLE
Update tor submodule repo URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/libevent/libevent.git
 [submodule "Tor/tor"]
 	path = Tor/tor
-	url = https://git.torproject.org/tor.git
+	url = https://gitlab.torproject.org/tpo/core/tor.git
 [submodule "Tor/arti"]
 	path = Tor/arti
 	url = https://gitlab.com/guardianproject/arti-mobile-ex.git


### PR DESCRIPTION
When I run `git submodule update --init --recursive`, git generates a warning:
```
warning: redirecting to https://gitlab.torproject.org/tpo/core/tor.git/
```

I don't know if this is intended, but I'm creating this PR to remove this warning.